### PR TITLE
Create Counter.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ See [Environment](#environment-variables) additional setup
    ```bash
    # root of the repository
    cd scaffold-hook/
+   forge build
    npm run deploy:anvil
    ```
 


### PR DESCRIPTION
Without this step, `npm run deploy:anvil` will fail.